### PR TITLE
removed 'com.google.android.material:material:1.3.0' from gradle

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'com.google.android.material:material:1.3.0'
+//    implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.12.1'
     implementation 'com.crystal:crystalrangeseekbar:1.1.3'
 //    implementation files('libs/mobile-ffmpeg-min-4.4.LTS.aar')


### PR DESCRIPTION
in this commit i have removed 'com.google.android.material' lib from build..gradle. as i seen it is not used anywhere and some time causing build issue as Android resource compile error. 'AAPT: error: duplicate value for resource 'attr/values' with config ''.'