### PR TITLE
cleared a bug in ActivityTrimmer.java in line 586,

### DIFF
--- a/library/src/main/java/com/gowtham/library/ui/ActVideoTrimmer.java
+++ b/library/src/main/java/com/gowtham/library/ui/ActVideoTrimmer.java
@@ -583,7 +583,7 @@ public class ActVideoTrimmer extends LocalizationActivity {
         //Dividing high resolution video by 2(ex: taken with camera)
         else if (w >= 800) {
             w = w / 2;
-            h = Integer.parseInt(height) / 2;
+            h = h / 2;
             return new String[]{"-ss", TrimmerUtils.formatCSeconds(lastMinValue),
                     "-i", String.valueOf(filePath),
                     "-s", w + "x" + h, "-r", "30",


### PR DESCRIPTION
Whenever we try to compress the video if the video is rotated then calculated w h is swapped but if w is greater than 800 swapped height is not being used instead actual retrieved height value is used, resulting video aspect ratio becomes 1:1, so i have corrected it